### PR TITLE
Run standalone jar or war instead of jar only

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,5 +6,4 @@ pom.xml.releaseBackup
 pom.xml.versionsBackup
 pom.xml.next
 release.properties
-
-
+.idea

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ services:
 
 language: go
 
-go: 1.6
+go: 1.7.x
 
 install:
   - go get github.com/openshift/source-to-image

--- a/s2i/bin/run
+++ b/s2i/bin/run
@@ -6,5 +6,5 @@ APP_TARGET=${APP_TARGET:-target}
 echo "---> Starting Spring Boot application"
 echo "--> # APP_TARGET = $APP_TARGET"
 echo "--> # JAVA_OPTS = $JAVA_OPTS"
-echo "---> Running application from jar ($(find $APP_TARGET -name *.jar)) ..."
-java $JAVA_OPTS -jar `find $APP_TARGET -name *.jar`
+echo "---> Running application from standalone jar/war..."
+java $JAVA_OPTS -jar `find $APP_TARGET -maxdepth 1 -regex ".*\(jar\|war\)"`

--- a/test/run
+++ b/test/run
@@ -28,7 +28,7 @@ cid_file=$($MKTEMP_EXEC -u --suffix=.cid)
 
 # Since we built the candidate image locally, we don't want S2I to attempt to pull
 # it from Docker hub
-s2i_args="--force-pull=false --loglevel=2"
+s2i_args="--pull-policy=never --loglevel=2"
 
 # Read exposed port from image meta data
 test_port="$(docker inspect --format='{{range $key, $value := .ContainerConfig.ExposedPorts }}{{$key}}{{end}}' ${IMAGE_NAME} | sed 's/\/.*//')"


### PR DESCRIPTION
Hi!

I had the issue that I had to deploy an standalone war which is nevertheless basically a spring boot app. So I used your image in my s2i process and modified it, as in this pull request, so that either a `*.jar` oder a `*.war` is started depending on the result of the maven build.
I hope you find that helpful. =)

BR,
Sven