### PR TITLE
Fix bc fail issue, source code not keep same location in Dockerfile and s2i assemble script

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,7 +30,7 @@ ENV MAVEN_HOME /usr/share/maven
 # Add configuration files, bashrc and other tweaks
 COPY ./s2i/bin/ $STI_SCRIPTS_PATH
 
-RUN chown -R 1001:0 /opt/app-root
+RUN chown -R 1001:0 ./
 USER 1001
 
 # Set the default CMD to print the usage of the language image


### PR DESCRIPTION
source code in Dockerfile will change owner to USER 1001. and location is /opt/app-root directory.
and in s2i/assemble script, source code will be installed in ./ directory.

echo "---> Installing application source"
cp -Rf /tmp/src/. ./

we need to keep the same location in Dockerfile and assemble script, otherwise, openshift build will fail with permission deny error.

I made this fix. to change Dockerfile as below:
 RUN chown -R 1001:0 ./